### PR TITLE
Don't create ~/.mlstats in mlstats_dot_dir()

### DIFF
--- a/pymlstats/utils.py
+++ b/pymlstats/utils.py
@@ -164,21 +164,8 @@ def mlstats_dot_dir ():
     try:
         return _dirs['dot']
     except KeyError:
-        pass
-
-    dot_dir = os.path.join (get_home_dir (), '.mlstats')
-    try:
-        os.mkdir (dot_dir, 0700)
-    except OSError, e:
-        if e.errno == errno.EEXIST:
-            if not os.path.isdir (dot_dir):
-                raise
-        else:
-            raise
-    
-    _dirs['dot'] = dot_dir
-
-    return dot_dir
+        _dirs['dot'] = os.path.join(get_home_dir (), '.mlstats')
+        return _dirs['dot']
 
 if __name__ == '__main__':
     print "mlstats dot dir: %s" % (mlstats_dot_dir ())


### PR DESCRIPTION
This function is used in pymlstats.main.Application as a constant, and is called
when the module is imported. Since Application uses os.makedirs() anyway, we can
safely drop the mkdir call from this function without any ill effects.

This fixes an issue where mlstats is installed (via setup.py install) in an
environment where $HOME is not writable.

Fixes https://bugzilla.libresoft.es/show_bug.cgi?id=352

Signed-off-by: Chow Loong Jin lchow@redhat.com
