### PR TITLE
ci: Add .travis.yml for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+#env:
+#    - DB=pgsql
+#    - DB=mysql
+python:
+    - "2.7"
+install:
+    - pip install psycopg2 MYSQL-python
+    - pip install mock nose nose-cov
+#before_script:
+#  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS mlstats;' -U postgres; fi"
+#  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database mlstats;' -U postgres; fi"
+#  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS mlstats'; fi"
+script: nosetests -sv --with-coverage --cover-package=pymlstats pymlstats
+after_success:
+  # Report coverage results to coveralls.io
+  - pip install coveralls
+  - coveralls
+#notifications:
+#    irc:
+#        channels:
+#            - "irc.freenode.org#metrics-grimoire"
+#        on_success: change


### PR DESCRIPTION
GitHub provides integration with travis-ci and coverage.io. Enabling travis-ci would allow us to automatically run the unit tests after any pull request and check if all tests pass before any review.

An example is available at https://travis-ci.org/gpoo/MailingListStats
and for tests coverage at https://coveralls.io/r/gpoo/MailingListStats

In order to enable the whole thing, it is required that the admin of MailingListStats allows the use of these external application to the repository. Nevertheless, if this is not part of the plan, still having this file might be useful for other developers (like me), so I don't need to rebase my branches for adding this file.

FWIW, the pull request has commented some parts that are not used at this moment, but might be required once other tests were added (e.g. checking the output of databases, or mocking http requests)
