### PR TITLE
Use a custom mailbox class with a file object. Fix #24

### DIFF
--- a/pymlstats/analyzer.py
+++ b/pymlstats/analyzer.py
@@ -39,7 +39,7 @@ from email.Iterators import typed_subpart_iterator
 import datetime
 import hashlib
 import sys
-from pymlstats.strictmbox import strict_mbox
+from pymlstats.strictmbox import CustomMailbox
 from pymlstats.utils import EMAIL_OBFUSCATION_PATTERNS
 
 
@@ -97,7 +97,8 @@ class MailArchiveAnalyzer:
     def get_messages(self):
 
         messages_list = []
-        mbox = strict_mbox(self.filepath)
+        fp = open(self.filepath, 'rb')
+        mbox = CustomMailbox(fp)
 
         non_parsed = 0
         for message in mbox:
@@ -199,6 +200,8 @@ class MailArchiveAnalyzer:
             # such header in the original message).
 
             messages_list.append(filtered_message)
+
+        fp.close()
 
         return messages_list, non_parsed
 

--- a/pymlstats/tests/test_analyzer.py
+++ b/pymlstats/tests/test_analyzer.py
@@ -40,6 +40,7 @@ class MailArchiveAnalyzerEncodingTest(unittest.TestCase):
             self.assertEqual(value, messages[0][key], output)
 
     def test_single_message_no_encoding(self):
+        '''Content-Transfer-Encoding: None'''
         maa = self.get_analyzer('pharo-single.mbox')
         messages, non_parsed = maa.get_messages()
         expected = {
@@ -52,7 +53,7 @@ class MailArchiveAnalyzerEncodingTest(unittest.TestCase):
             'in-reply-to': None,
             'list-id': None,
             'message-id': u'<4CF64D10.9020206@domain.com>',
-            'received': None,
+            'received': '2010-12-01 08:26:40',
             'references': None,
             'subject': u'[List-name] Protocol Buffers anyone?',
             'from': [(u'Göran Lastname', u'goran@domain.com')],
@@ -80,7 +81,7 @@ class MailArchiveAnalyzerEncodingTest(unittest.TestCase):
                 u'GNOME Desktop Development List '
                 u'<desktop-devel-list.gnome.org>',
             'message-id': u'<87iqzlofqu.fsf@avet.kvota.net>',
-            'received': None,
+            'received': '2008-03-17 09:35:25',
             'references':
                u'<1204225143.12769.9.camel@localhost.localdomain>\n'
                u'\t<1204236062.14337.5.camel@localhost.localdomain>',
@@ -122,7 +123,7 @@ class MailArchiveAnalyzerEncodingTest(unittest.TestCase):
                 u'GNOME Desktop Development List '
                 u'<desktop-devel-list.gnome.org>',
             'message-id': u'<1205749169.7470.2.camel@aragorn>',
-            'received': None,
+            'received': '2008-03-17 10:19:47',
             'references':
                 u'<1204225143.12769.9.camel@localhost.localdomain>\n'
                 u'\t<1204236062.14337.5.camel@localhost.localdomain>\n'
@@ -169,7 +170,7 @@ class MailArchiveAnalyzerEncodingTest(unittest.TestCase):
                 u'GNOME Desktop Development List '
                 u'<desktop-devel-list.gnome.org>',
             'message-id': u'<BAY12-DAV6Dhd2stb2e0000c0ce@hotmail.com>',
-            'received': None,
+            'received': '2004-09-22 05:05:28',
             'references': None,
             'from': [(u'Eugenia Loli-Queru', u'eloli@hotmail.com')],
             'to': [('', u'language-bindings@gnome.org'),


### PR DESCRIPTION
Introduced a code deprecated in Python 2.7 (and removed from3.x) that handles the mailbox as a file object (file pointer). This should allow us to parse streams, and avoid uncompressing and
storing files.

It was removed from Python because it does not allow to modify a mbox. However, we don't modify a mbox. So, this fits with the purpose of `mlstats`.

As a consequence, this patch also solves the issue of not processing the 'received' header (Fix #24).
I updated the unit test accordingly.
