### PR TITLE
Make "Found substring" message more explainable e.g. Current month detected

### DIFF
--- a/pymlstats/main.py
+++ b/pymlstats/main.py
@@ -314,7 +314,9 @@ class Application(object):
                 this_month = find_current_month(link)
 
                 if this_month:
-                    self.__print_output('Current month detected: Found substring %s in URL %s...' % (this_month, link))
+                    self.__print_output(
+                        'Current month detected: '
+                        'Found substring %s in URL %s...' % (this_month, link))
                     self.__print_output('Retrieving %s...' % link)
                     retrieve_remote_file(link, destfilename,
                                          self.web_user, self.web_password)


### PR DESCRIPTION
During playing around with mlstats a message appeared in the stdout:

```
Found substring 2014-June in URL http://lists.typo3.org/pipermail/typo3-dev/2014-June.txt.gz...
```

After reading i wasn`t sure what does mean at the first time.
I recognised that this only occurred at the current month. After a look in the source: yep i am right.
To avoid such a feeling for other people i changed the message to something more meaningful:

```
Current month detected: Found substring 2014-June in URL http://lists.typo3.org/pipermail/typo3-dev/2014-June.txt.gz...
```
