### PR TITLE
Changed message_body from TEXT to MEDIUMTEXT, because we got messages > 65.535 bytes

### DIFF
--- a/db/data_model_mysql.sql
+++ b/db/data_model_mysql.sql
@@ -37,7 +37,7 @@ CREATE TABLE messages (
     arrival_date DATETIME NULL,
     arrival_date_tz INTEGER(11) NULL,
     subject VARCHAR(255) CHARACTER SET utf8 NULL,
-    message_body TEXT CHARACTER SET utf8 NULL,
+    message_body MEDIUMTEXT CHARACTER SET utf8 NULL,
     is_response_of VARCHAR(255) CHARACTER SET utf8 NULL,
     mail_path TEXT CHARACTER SET utf8 NULL,
     PRIMARY KEY(message_ID),

--- a/pymlstats/db/database.py
+++ b/pymlstats/db/database.py
@@ -22,14 +22,20 @@ This module contains a the definition of the generic SQL tables used
 by mlstats.
 """
 
+import sqlalchemy
 from sqlalchemy import create_engine, Column, ForeignKey, ForeignKeyConstraint
 from sqlalchemy import DateTime, Enum, NUMERIC, TEXT, VARCHAR
+from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.ext.declarative import declarative_base
 
 __all__ = ['Base', 'MailingLists', 'CompressedFiles', 'People',
            'Messages', 'MessagesPeople', 'MailingListsPeople']
 
 Base = declarative_base()
+
+
+def MediumText():
+    return sqlalchemy.Text().with_variant(MEDIUMTEXT(), 'mysql')
 
 
 class MailingLists(Base):
@@ -108,7 +114,7 @@ class Messages(Base):
     arrival_date = Column(DateTime)
     arrival_date_tz = Column(NUMERIC(11))
     subject = Column(VARCHAR(1024))
-    message_body = Column(TEXT)
+    message_body = Column(MediumText())
     is_response_of = Column(VARCHAR(255), index=True)
     mail_path = Column(TEXT)
 


### PR DESCRIPTION
Hey,

during analysing the TYPO3-Dev mailing list (http://lists.typo3.org/pipermail/typo3-dev/) i got some output like:

```
...
Analyzing /home/vagrant/.mlstats/compressed/lists.typo3.org/pipermail/typo3-dev/2013-January.txt.gz
Analyzing /home/vagrant/.mlstats/compressed/lists.typo3.org/pipermail/typo3-dev/2013-February.txt.gz
Analyzing /home/vagrant/.mlstats/compressed/lists.typo3.org/pipermail/typo3-dev/2013-March.txt.gz
Analyzing /home/vagrant/.mlstats/compressed/lists.typo3.org/pipermail/typo3-dev/2013-April.txt.gz
/vagrant/MailingListStats.git/pymlstats/db/mysql.py:210: Warning: Data truncated for column 'message_body' at row 1
  self.write_cursor.execute(query_message, values)
Analyzing /home/vagrant/.mlstats/compressed/lists.typo3.org/pipermail/typo3-dev/2013-May.txt.gz
Analyzing /home/vagrant/.mlstats/compressed/lists.typo3.org/pipermail/typo3-dev/2013-June.txt.gz
...
```

For the complete analyse i got 4 of this messages.
After some debugging i found that the mysql field messages.message_body is TEXT and can store 65.535 bytes bytes.
In the TYPO3 dev mailing list some messages are longer like:
- [[TYPO3-dev]  Import Selection with TYPO3 Element Browser in 6.04](http://lists.typo3.org/pipermail/typo3-dev/2013-April/046711.html): 72.029 chars
- [[TYPO3-dev] Tester needed : gridelements_fce + generator](http://lists.typo3.org/pipermail/typo3-dev/2014-April/048265.html): 788.257 chars

Of course, the content represents some crypted stuff, but this does not matter.
In my opinion is the content important, because the meaningful of the content depends on the question.
