### PR TITLE
Decouple mail retrieval from SQL-db wrapping Application class

### DIFF
--- a/pymlstats/analyzer.py
+++ b/pymlstats/analyzer.py
@@ -281,7 +281,7 @@ class MailArchiveAnalyzer:
 
 if __name__ == '__main__':
     import pprint
-    from main import MBoxArchive
+    from archives import MBoxArchive
 
     # Print analyzer's output to check manually the parsing. In can
     # be used with egrep to filter out specific fields.

--- a/pymlstats/archives.py
+++ b/pymlstats/archives.py
@@ -1,0 +1,102 @@
+# -*- coding:utf-8 -*-
+#
+# Copyright (C) 2007-2010 Libresoft Research Group
+# Copyright (C) 2015 Germán Poo-Caamaño
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02111-1301, USA.
+#
+# Authors : Israel Herraiz <herraiz@gsyc.escet.urjc.es>
+#           Germán Poo-Caamaño <gpoo@gnome.org>
+
+import bz2
+import gzip
+import zipfile
+
+import os.path
+import urlparse
+
+from htmlparser import MyHTMLParser
+from utils import mlstats_dot_dir, check_compressed_file
+
+
+COMPRESSED_DIR = os.path.join(mlstats_dot_dir(), 'compressed')
+
+
+class MailingList(object):
+    def __init__(self, url_or_dirpath, compressed_dir=COMPRESSED_DIR):
+        rpath = url_or_dirpath.rstrip(os.path.sep)
+
+        url = urlparse.urlparse(rpath)
+        lpath = url.path.rstrip(os.path.sep)
+
+        self._local = url.scheme == 'file' or len(url.scheme) == 0
+        self._location = os.path.realpath(lpath) if self._local else rpath
+        self._alias = os.path.basename(self._location) or url.netloc
+
+        # Define local directories to store mboxes archives
+        target = os.path.join(url.netloc, lpath.lstrip(os.path.sep))
+        target = target.rstrip(os.path.sep)
+
+        self._compressed_dir = os.path.join(compressed_dir, target)
+
+    @property
+    def location(self):
+        return self._location
+
+    @property
+    def alias(self):
+        return self._alias
+
+    @property
+    def compressed_dir(self):
+        return self._compressed_dir
+
+    def is_local(self):
+        return self._local
+
+    def is_remote(self):
+        return not self.is_local()
+
+
+class MBoxArchive(object):
+
+    def __init__(self, filepath, url=None):
+        self._filepath = filepath
+        self.url = url
+        self._compressed = check_compressed_file(filepath)
+
+    @property
+    def filepath(self):
+        return self._filepath
+
+    @property
+    def container(self):
+        if not self.is_compressed():
+            return open(self.filepath, 'rb')
+
+        if self.compressed_type == 'gz':
+            return gzip.GzipFile(self.filepath, mode='rb')
+        elif self.compressed_type == 'bz2':
+            return bz2.BZ2File(self.filepath, mode='rb')
+        elif self.compressed_type == 'zip':
+            return zipfile.ZipFile(self.filepath, mode='rb')
+
+    @property
+    def compressed_type(self):
+        return self._compressed
+
+    def is_compressed(self):
+        return self._compressed is not None

--- a/pymlstats/backends.py
+++ b/pymlstats/backends.py
@@ -24,9 +24,8 @@
 import gzip
 import os.path
 
-from htmlparser import MyHTMLParser
-from utils import find_current_month, create_dirs, fetch_remote_resource,\
-    file_type
+from htmlparser import MyHTMLParser, fetch_remote_resource
+from utils import find_current_month, create_dirs, file_type
 from archives import MBoxArchive, MailingList
 
 

--- a/pymlstats/backends.py
+++ b/pymlstats/backends.py
@@ -1,0 +1,245 @@
+# -*- coding:utf-8 -*-
+#
+# Copyright (C) 2007-2010 Libresoft Research Group
+# Copyright (C) 2015 Germán Poo-Caamaño
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02111-1301, USA.
+#
+# Authors : Israel Herraiz <herraiz@gsyc.escet.urjc.es>
+#           Germán Poo-Caamaño <gpoo@gnome.org>
+
+import gzip
+import os.path
+
+from htmlparser import MyHTMLParser
+from utils import find_current_month, create_dirs, fetch_remote_resource,\
+    file_type
+from archives import MBoxArchive, MailingList
+
+
+GMANE_DOMAIN = 'gmane.org'
+GMANE_URL = 'http://dir.gmane.org/'
+GMANE_DOWNLOAD_URL = 'http://download.gmane.org/'
+GMANE_LIMIT = 2000
+
+
+class BaseArchive(object):
+    """Base class to handle mailing lists archives.
+
+    Used to process local and remote mailing lists archives via generators.
+    An Archive class must have the following attributes:
+    - mailing_list: (MailingList) a Mailing List object with its location.
+    - be_quite: (boolean) tell if this class should not print any text
+      indicating progress of a task (e.g. while downloading files).
+    """
+    def __init__(self, mailing_list, be_quiet=False):
+        # Don't show messages when retrieveing and analyzing files
+        self.be_quiet = be_quiet
+
+        # URLs or local files to be analyzed
+        self.url = mailing_list.location
+        self.output_dir = mailing_list.compressed_dir
+
+        self.mailing_list = mailing_list
+
+    def _print_output(self, text):
+        if not self.be_quiet:
+            print text
+
+    def _create_download_dirs(self):
+        # Remote archives are retrieved and stored in output_dir.
+        # Local compressed archives are left in their original location.
+        if self.mailing_list.is_remote():
+            create_dirs(self.mailing_list.compressed_dir)
+
+
+class RemoteArchive(BaseArchive):
+    """Generic class to handle remove mailing lists archives.
+
+    Use this class to implement mechanisms to download mailing list archives
+    from Internet.
+    """
+    def __init__(self, mailing_list, be_quiet=False, force=False,
+                 web_user=None, web_password=None):
+        super(RemoteArchive, self).__init__(mailing_list, be_quiet)
+
+        # User and password to make login in case the archives
+        # are set to private
+        self.web_user = web_user
+        self.web_password = web_password
+
+        # Force to download and parse any link found in the given URL
+        self.force = force
+
+    def _retrieve_remote_file(self, url, destfilename=None):
+        """Retrieve a file from a remote location.
+
+        It logins in the archives private page if necessary.
+        """
+
+        # Creat a temporary file is no destination is given
+        if not destfilename:
+            destfilename = os.tmpnam()
+
+        content = fetch_remote_resource(url, self.web_user, self.web_password)
+
+        if file_type(content) is None:
+            fd = gzip.GzipFile(destfilename, 'wb')
+        else:
+            fd = open(destfilename, 'wb')
+
+        fd.write(content)
+        fd.close()
+
+        return destfilename, len(content)
+
+
+class MailmanArchive(RemoteArchive):
+    """Class to download mboxes from Mailman interface."""
+
+    def fetch(self):
+        """Get all the links listed in the Mailing List's URL.
+
+        The archives are usually retrieved in descending chronological
+        order (newest archives are always shown on the top of the archives).
+        Reverse the list to analyze in chronological order.
+        """
+
+        mailing_list = self.mailing_list
+
+        htmlparser = MyHTMLParser(mailing_list.location,
+                                  self.web_user, self.web_password)
+        links = htmlparser.get_mboxes_links(self.force)
+
+        for link in links:
+            basename = os.path.basename(link)
+            destfilename = os.path.join(mailing_list.compressed_dir, basename)
+
+            try:
+                # If the URL is for the current month, always retrieve.
+                # Otherwise, check visited status & local files first
+                this_month = find_current_month(link)
+
+                if this_month:
+                    self._print_output(
+                        'Current month detected: '
+                        'Found substring %s in URL %s...' % (this_month, link))
+                    self._print_output('Retrieving %s...' % link)
+                    self._retrieve_remote_file(link, destfilename)
+                elif os.path.exists(destfilename):
+                    self._print_output('Already downloaded %s' % link)
+                else:
+                    self._print_output('Retrieving %s...' % link)
+                    self._retrieve_remote_file(link, destfilename)
+            except IOError:
+                self._print_output("Unknown URL: " + link + ". Skipping.")
+                continue
+
+            yield MBoxArchive(destfilename, link)
+
+
+class GmaneArchive(RemoteArchive):
+    """Class to download mboxes from Gmane interface."""
+
+    def __init__(self, mailing_list, be_quiet=False, force=False,
+                 web_user=None, web_password=None, offset=0):
+        super(GmaneArchive, self).__init__(mailing_list, be_quiet, force,
+                                           web_user, web_password)
+        self.offset = offset
+
+    def fetch(self):
+        """Get all the links listed in the Mailing List's URL.
+
+        The archives are usually retrieved in descending chronological
+        order (newest archives are always shown on the top of the archives).
+        Reverse the list to analyze in chronological order.
+        """
+
+        mailing_list = self.mailing_list
+
+        gmane_url = GMANE_DOWNLOAD_URL + mailing_list.alias
+        from_msg = self.offset if self.offset else self.__get_gmane_offset()
+
+        while True:
+            to_msg = from_msg + GMANE_LIMIT
+            url = gmane_url + '/' + str(from_msg) + '/' + str(to_msg)
+            archive_url = gmane_url + '/' + str(from_msg)
+            filename = os.path.join(mailing_list.compressed_dir, str(from_msg))
+
+            self._print_output('Retrieving %s...' % url)
+            fp, size = self._retrieve_remote_file(url, filename)
+
+            # Check whether we have read the last message.
+            # In Gmane, an empty page means we reached the last msg
+            # Therefore, we also remove the file before leaving.
+            if not size:
+                os.unlink(fp)
+                break
+
+            from_msg = to_msg
+
+            yield MBoxArchive(filename, archive_url)
+
+    def __get_gmane_offset(self):
+        offsets = [0]
+        output_dir = self.mailing_list.compressed_dir
+
+        _, _, files = os.walk(output_dir).next()
+        for f in files:
+            try:
+                offsets.append(int(f))
+            except ValueError:
+                # We omit those files whose name is not a number (offset),
+                # because for gmane mlstats names the files with the offset.
+                pass
+
+        return max(offsets)
+
+
+class LocalArchive(BaseArchive):
+    """Class to walk through mboxes stored locally."""
+
+    def fetch(self):
+        """Walk the mailing list directory looking for archives"""
+
+        mailing_list = self.mailing_list
+
+        if os.path.isfile(mailing_list.location):
+            yield MBoxArchive(mailing_list.location, mailing_list.location)
+        else:
+            for root, dirs, files in os.walk(mailing_list.location):
+                for filename in sorted(files):
+                    location = os.path.join(root, filename)
+                    yield MBoxArchive(location, location)
+
+
+if __name__ == '__main__':
+    import sys
+    import pprint
+
+    # Test case
+    ml = MailingList(url_or_dirpath=sys.argv[1], compressed_dir=sys.argv[2])
+    if ml.is_local():
+        o = LocalArchive(ml)
+    elif ml.location.startswith(GMANE_URL):
+        o = GmaneArchive(ml)
+    else:
+        o = MailmanArchive(ml)
+
+    o._create_download_dirs()
+
+    for mla in o.fetch():
+        pprint.pprint(mla.url)

--- a/pymlstats/tests/test_analyzer.py
+++ b/pymlstats/tests/test_analyzer.py
@@ -23,7 +23,7 @@ import os
 from datetime import datetime
 
 from pymlstats import analyzer
-from pymlstats.main import MBoxArchive
+from pymlstats.archives import MBoxArchive
 
 CUR_DIR = os.path.dirname(__file__)
 DATA_PATH = os.path.join(CUR_DIR, 'data')

--- a/pymlstats/tests/test_archives.py
+++ b/pymlstats/tests/test_archives.py
@@ -20,7 +20,7 @@
 import unittest
 import os
 
-from pymlstats.main import MailingList, COMPRESSED_DIR
+from pymlstats.archives import MailingList, COMPRESSED_DIR
 
 
 class MailingListTest(unittest.TestCase):

--- a/pymlstats/utils.py
+++ b/pymlstats/utils.py
@@ -29,14 +29,10 @@ Some utils functions for MLStats
 """
 
 from fileextractor import FileExtractor
-import gzip
 import os.path
 import tempfile
-import urllib
-import urllib2
 import shutil
 import datetime
-import cStringIO
 
 COMPRESSED_TYPES = ['.gz', '.bz2', '.zip', '.tar',
                     '.tar.gz', '.tar.bz2', '.tgz', '.tbz']
@@ -89,33 +85,6 @@ def check_compressed_file(filename):
     with open(filename) as f:
         magic_number = f.read(4)
     return file_type(magic_number)
-
-
-def fetch_remote_resource(url, user=None, password=None):
-    user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.2 ' \
-                 '(KHTML, like Gecko) Ubuntu/11.04 Chromium/15.0.871.0 ' \
-                 'Chrome/15.0.871.0 Safari/535.2'
-    headers = {'User-Agent': user_agent,
-               'Accept-Encoding': 'gzip, deflate'}
-
-    postdata = None
-    if user:
-        postdata = urllib.urlencode({'username': user, 'password': password})
-
-    request = urllib2.Request(url, postdata, headers)
-    response = urllib2.urlopen(request)
-    data = response.read()
-
-    if response.info().getheader('content-encoding') == 'gzip':
-        data = cStringIO.StringIO(data)
-        content = gzip.GzipFile(mode='r', compresslevel=0,
-                                fileobj=data).read()
-    else:
-        content = data
-
-    response.close()
-
-    return content
 
 
 def file_type(content):

--- a/pymlstats/utils.py
+++ b/pymlstats/utils.py
@@ -132,28 +132,6 @@ def file_type(content):
     return None
 
 
-def retrieve_remote_file(url, destfilename=None, web_user=None,
-                         web_password=None):
-    """Retrieve a file from a remote location. It logins in the
-    archives private page if necessary."""
-
-    # If not dest dir, then store file in a temp file
-    if not destfilename:
-        destfilename = os.tmpnam()
-
-    content = fetch_remote_resource(url, web_user, web_password)
-
-    if file_type(content) is None:
-        fd = gzip.GzipFile(destfilename, 'wb')
-    else:
-        fd = open(destfilename, 'wb')
-
-    fd.write(content)
-    fd.close()
-
-    return destfilename, len(content)
-
-
 def uncompress_file(filepath, extension, output_dir=None):
     """This function uncompress the file, and return
     the extension for the uncompressed file."""


### PR DESCRIPTION
Move classes related to Mail Archiving and the archive retrieval
process out of the Application class.

This is the first step towards fetching mail archives as a library,
in addition to the running the application (mlstats).