### PR TITLE
Add support for environment variables as config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ You are ready to use `mlstats`.
 Running MLStats
 ---------------
 
+In general configuration is applied by command line arguments or environment variables.
+Checkout existing arguments and environment variables via `mlstats --help`.
+
 ### Basic Setup Using Sqlite
 
 To run `mlstats` without the hassle of setting a database, you can use

--- a/pymlstats/__init__.py
+++ b/pymlstats/__init__.py
@@ -58,14 +58,17 @@ General options:
   -h, --help        Print this usage message.
   -q, --quiet       Do not show messages about the progress in the
                     retrieval and analysis of the archives.
+                    Environment variable "MLSTATS_QUIET"
   --version         Show the version number and exit.
   --force           Force mlstats to download and parse any link found
                     in a given URL (only valid for remote links, neither
                     Gmane links nor local files).
+                    Environment variable "MLSTATS_FORCE"
   -                 Read URLs from the standard input. This will ignore
                     all the URLs passed via the command line.
   --compressed-dir  Path to a folder where the archives of the mailing
                     list will be stored.
+                    Environment variable "MLSTATS_COMPRESSED_DIR"
 
 
 Report options:
@@ -74,29 +77,38 @@ Report options:
                     (default is standard output)
                     WARNING: The report file will be overwritten if
                     already exists.
+                    Environment variable "MLSTATS_REPORT_FILENAME"
   --no-report       Do not generate a report after the retrieval and
                     parsing of the archives.
+                    Environment variable "MLSTATS_REPORT"
 
 
 Private archives options:
 
   --web-user        If the archives of the mailing list are private, use
                     this username to login in order to retrieve the files.
+                    Environment variable "MLSTATS_WEB_USERNAME"
   --web-password    If the archives of the mailing list are private, use
                     this password to login in order to retrieve the files.
+                    Environment variable "MLSTATS_WEB_PASSWORD"
 
 Database options:
 
   --db-driver          Database backend: mysql, postgres, or sqlite
                        (default is mysql)
+                       Environment variable "MLSTATS_DB_DRIVER"
   --db-user            Username to connect to the database
                        (default is operator)
+                       Environment variable "MLSTATS_DB_USERNAME"
   --db-password        Password to connect to the database
                        (default is operator)
+                       Environment variable "MLSTATS_DB_PASSWORD"
   --db-name            Name of the database that contains data previously
                        analyzed (default is mlstats)
+                       Environment variable "MLSTATS_DB_NAME"
   --db-hostname        Name of the host with a database server running
                        (default is localhost)
+                       Environment variable "MLSTATS_DB_HOSTNAME"
 """
 
 

--- a/pymlstats/__init__.py
+++ b/pymlstats/__init__.py
@@ -31,7 +31,7 @@ options are changed.
 
 import sys
 import getopt
-import os.path
+import os
 from main import Application
 from version import mlstats_version
 
@@ -112,18 +112,18 @@ def start():
                  "compressed-dir="]
 
     # Default options
-    db_driver = 'mysql'
-    db_user = None
-    db_password = None
-    db_hostname = None
-    db_name = 'mlstats'
-    web_user = None
-    web_password = None
-    compressed_dir = None
-    report_filename = ''
-    report = True
-    quiet = False
-    force = False
+    db_driver = os.getenv('MLSTATS_DB_DRIVER', 'mysql')
+    db_user = os.getenv('MLSTATS_DB_USERNAME', None)
+    db_password = os.getenv('MLSTATS_DB_PASSWORD', None)
+    db_hostname = os.getenv('MLSTATS_DB_HOSTNAME', None)
+    db_name = os.getenv('MLSTATS_DB_NAME', 'mlstats')
+    web_user = os.getenv('MLSTATS_WEB_USERNAME', None)
+    web_password = os.getenv('MLSTATS_WEB_PASSWORD', None)
+    compressed_dir = os.getenv('MLSTATS_COMPRESSED_DIR', None)
+    report_filename = os.getenv('MLSTATS_REPORT_FILENAME', '')
+    report = os.getenv('MLSTATS_REPORT', True)
+    quiet = os.getenv('MLSTATS_QUIET', False)
+    force = os.getenv('MLSTATS_FORCE', False)
     urls = ''
 
     try:


### PR DESCRIPTION
In terms of the 12 factor apps configuration settings should be applied as env vars as well.
See http://12factor.net/config

This pull request enables the configuration for mlstats via env vars.
All other configuration types (incl. default values) are still supported.

This env vars are supported:
- `MLSTATS_DB_DRIVER`
- `MLSTATS_DB_USERNAME`
- `MLSTATS_DB_PASSWORD`
- `MLSTATS_DB_HOSTNAME`
- `MLSTATS_DB_NAME`
- `MLSTATS_WEB_USERNAME`
- `MLSTATS_WEB_PASSWORD`
- `MLSTATS_COMPRESSED_DIR`
- `MLSTATS_REPORT_FILENAME`
- `MLSTATS_REPORT`
- `MLSTATS_QUIET`
- `MLSTATS_FORCE`

The names of the env vars follows the schema `APPNAME_SECTION_CONFIG`.

With this PR the usage of mlstats for Docker or "cloud" envs is much easier.

See [12 Fractured Apps](https://medium.com/@kelseyhightower/12-fractured-apps-1080c73d481c#.dothyjoc9) for further read.

See https://github.com/MetricsGrimoire/sortinghat/pull/45 for the sortinghat edition.
