### PR TITLE
Add mailing_list_url column to PSQL schema

### DIFF
--- a/db/data_model_pg.sql
+++ b/db/data_model_pg.sql
@@ -45,6 +45,7 @@ CREATE INDEX response ON messages (is_response_of);
 CREATE TABLE messages_people (
     type_of_recipient VARCHAR(25) NOT NULL DEFAULT 'From'
         CHECK (type_of_recipient IN ('From', 'To', 'Cc')),
+    mailing_list_url VARCHAR(255) NOT NULL,
     message_id VARCHAR(255) NOT NULL,
     email_address VARCHAR(255) NOT NULL,
     PRIMARY KEY(type_of_recipient, message_id, email_address)


### PR DESCRIPTION
Was just trying out MLStats for the first time today, with my preferred PSQL database and spotted that the schema is missing a column, causing `mlstats` to bomb out. Copied the appropriate line from the MySQL schema (https://github.com/MetricsGrimoire/MailingListStats/blob/master/db/data_model_mysql.sql#L54) to fix.